### PR TITLE
Remove extraneous `removeArrangedSubview` call

### DIFF
--- a/StackViewController/UIStackViewExtensions.swift
+++ b/StackViewController/UIStackViewExtensions.swift
@@ -11,7 +11,6 @@ import UIKit
 extension UIStackView {
     public func removeAllArrangedSubviews() {
         arrangedSubviews.forEach {
-            removeArrangedSubview($0)
             $0.removeFromSuperview()
         }
     }


### PR DESCRIPTION
The documentation for `removeArrangedSubview` says that you can remove a subview with `removeFromSuperview` and it will automatically remove the view from the stack view's `arrangedSubviews`.