### PR TITLE
Fix usage of axis parameter in SeparatorView

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -16,7 +16,7 @@ class ViewController: UIViewController {
     
     init() {
         stackViewController = StackViewController()
-        stackViewController.stackViewContainer.separatorViewFactory = SeparatorView.init
+        stackViewController.stackViewContainer.separatorViewFactory = StackViewContainer.createSeparatorViewFactory { _ in }
         
         super.init(nibName: nil, bundle: nil)
         

--- a/StackViewController/SeparatorView.swift
+++ b/StackViewController/SeparatorView.swift
@@ -54,8 +54,8 @@ public class SeparatorView: UIView {
         sizeConstraint?.active = false
         let layoutAttribute: NSLayoutAttribute = {
             switch axis {
-            case .Vertical: return .Height
-            case .Horizontal: return .Width
+            case .Horizontal: return .Height
+            case .Vertical: return .Width
             }
         }()
         sizeConstraint = NSLayoutConstraint(
@@ -79,8 +79,8 @@ public class SeparatorView: UIView {
         guard separatorThickness > 0 else { return }
         let edge: CGRectEdge = {
             switch axis {
-            case .Vertical: return .MinXEdge
-            case .Horizontal: return .MaxYEdge
+            case .Horizontal: return .MinXEdge
+            case .Vertical: return .MaxYEdge
             }
         }()
         let (_, separatorRect) = bounds.divide(separatorInset, fromEdge: edge)

--- a/StackViewController/StackViewContainer.swift
+++ b/StackViewController/StackViewContainer.swift
@@ -56,6 +56,25 @@ public class StackViewContainer: UIView, UIScrollViewDelegate {
         didSet { relayoutContent(false) }
     }
     
+    /// Creates a separator view factory that uses the `SeparatorView` class
+    /// provided by this framework to render the view. The separator will
+    /// automatically use the correct orientation based on the orientation
+    /// of the stack view. The `configurator` block can be used to customize
+    /// the appearance of the separator.
+    public static func createSeparatorViewFactory(configurator: SeparatorView -> Void) -> SeparatorViewFactory {
+        return { axis in
+            let separatorAxis: UILayoutConstraintAxis = {
+                switch axis {
+                case .Horizontal: return .Vertical
+                case .Vertical: return .Horizontal
+                }
+            }()
+            let separatorView = SeparatorView(axis: separatorAxis)
+            configurator(separatorView)
+            return separatorView
+        }
+    }
+    
     /// The axis (direction) that content is laid out in. Setting the axis via
     /// this property instead of `stackView.axis` ensures that any separator
     /// views are recreated to account for the change in layout direction.

--- a/StackViewControllerTests/StackViewContainerTests.swift
+++ b/StackViewControllerTests/StackViewContainerTests.swift
@@ -17,7 +17,7 @@ class StackViewContainerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         stackViewContainer = StackViewContainer()
-        stackViewContainer.separatorViewFactory = SeparatorView.init
+        stackViewContainer.separatorViewFactory = StackViewContainer.createSeparatorViewFactory { _ in }
     }
     
     private func contentViewWithTag(tag: Int) -> ContentView {
@@ -243,6 +243,7 @@ class StackViewContainerTests: XCTestCase {
     }
     
     func testSeparatorViewFactorySetter() {
+        let separatorViewFactory = stackViewContainer.separatorViewFactory
         stackViewContainer.separatorViewFactory = nil
         stackViewContainer.contentViews = [
             contentViewWithTag(1),
@@ -251,7 +252,7 @@ class StackViewContainerTests: XCTestCase {
         XCTAssertEqual(2, stackViewContainer.contentViews.count)
         XCTAssertEqual([1, 2], stackViewContainer.stackView.arrangedSubviews.map { $0.tag })
         
-        stackViewContainer.separatorViewFactory = SeparatorView.init
+        stackViewContainer.separatorViewFactory = separatorViewFactory
         XCTAssertEqual(2, stackViewContainer.contentViews.count)
         XCTAssertEqual([1, 0, 2], stackViewContainer.stackView.arrangedSubviews.map { $0.tag })
     }
@@ -267,7 +268,7 @@ class StackViewContainerTests: XCTestCase {
                 .filter { $0.isKindOfClass(SeparatorView.self) }
                 .map { $0 as! SeparatorView }
             separators.forEach {
-                XCTAssertEqual(axis, $0.axis)
+                XCTAssertNotEqual(axis, $0.axis)
             }
         }
         


### PR DESCRIPTION
Previously, the `SeparatorView`'s *actual* axis would be perpendicular to the axis of the stack view, which was passed into this initializer. This (largely unintentional) convention was convenient because you could use the stack view's axis directly as the parameter to the `SeparatorView` initializer, but this made no sense when using the `SeparatorView` as a standalone view.

This pull request changes that convention to the opposite (the `axis` parameter passed into init is the actual axis of the separator) and adds a convenience method for creating separator view factories because it's no longer a trivial one liner.