### PR TITLE
Give access to container through computed properties

### DIFF
--- a/StackViewController/StackViewController.swift
+++ b/StackViewController/StackViewController.swift
@@ -18,6 +18,47 @@ open class StackViewController: UIViewController {
     /// `axis`, and `separatorViewFactory`. All other operations should
     /// be performed via this controller and not directly via the container view.
     open lazy var stackViewContainer = StackViewContainer()
+
+    /// An optional background view that is shown behind the stack view. The
+    /// top of the background view will be kept pinned to the top of the scroll
+    /// view bounds, even when bouncing.
+    open var backgroundView: UIView? {
+        get {
+            return stackViewContainer.backgroundView
+        }
+        set {
+            stackViewContainer.backgroundView = newValue
+        }
+    }
+
+    /// The stack view. It is not safe to modify the arranged subviews directly
+    /// via the stack view. The items collection accessors on
+    /// `StackViewController` should be used instead. It is also not safe to modify
+    /// the `axis` property. `StackViewController.axis` should be set instead.
+    open var stackView: UIStackView {
+        return stackViewContainer.stackView
+    }
+
+    /// The axis (direction) that content is laid out in. Setting the axis via
+    /// this property instead of `stackView.axis` ensures that any separator
+    /// views are recreated to account for the change in layout direction.
+    open var axis: UILayoutConstraintAxis {
+        get {
+            return stackViewContainer.axis
+        }
+        set {
+            stackViewContainer.axis = newValue
+        }
+    }
+
+    open var separatorViewFactory: StackViewContainer.SeparatorViewFactory? {
+        get {
+            return stackViewContainer.separatorViewFactory
+        }
+        set {
+            stackViewContainer.separatorViewFactory = newValue
+        }
+    }
     
     fileprivate var _items = [StackViewItem]()
     

--- a/StackViewController/StackViewController.swift
+++ b/StackViewController/StackViewController.swift
@@ -17,6 +17,7 @@ open class StackViewController: UIViewController {
     /// This is exposed for configuring `backgroundView`, `stackView`
     /// `axis`, and `separatorViewFactory`. All other operations should
     /// be performed via this controller and not directly via the container view.
+    @available(*, deprecated, message: "Use the `backgroundView`, `stackView`, `axis`, `separatorViewFactory` or `scrollView` property on `StackViewController` instead.")
     open lazy var stackViewContainer = StackViewContainer()
 
     /// An optional background view that is shown behind the stack view. The

--- a/StackViewController/StackViewController.swift
+++ b/StackViewController/StackViewController.swift
@@ -59,6 +59,13 @@ open class StackViewController: UIViewController {
             stackViewContainer.separatorViewFactory = newValue
         }
     }
+
+    /// The scroll view that is the superview of the stack view.
+    /// The scrollview automatically accommodates the keyboard. This replicates the behaviour
+    /// implemented by `UITableView`.
+    open var scrollView: UIScrollView {
+        return stackViewContainer.scrollView
+    }
     
     fileprivate var _items = [StackViewItem]()
     

--- a/StackViewController/StackViewController.swift
+++ b/StackViewController/StackViewController.swift
@@ -32,6 +32,15 @@ open class StackViewController: UIViewController {
         }
     }
 
+    open var backgroundColor: UIColor? {
+        get {
+            return stackViewContainer.backgroundColor
+        }
+        set {
+            stackViewContainer.backgroundColor = newValue
+        }
+    }
+
     /// The stack view. It is not safe to modify the arranged subviews directly
     /// via the stack view. The items collection accessors on
     /// `StackViewController` should be used instead. It is also not safe to modify


### PR DESCRIPTION
Allow consumers of the `StackViewController` API to access the
`backgroundView`, `stackView`, `axis`, `separatorViewFactory` and `scrollView`
properties of the `StackViewContainer` without having knowledge of the
container. This allows us to modify the internals of
`StackViewController` without having to make breaking changes to the
public API.

Also deprecates the `stackViewContainer` property to allow us to make it private in a future release.

Ideally these other properties wouldn't be accessible either but I think we should take this one small change at a time.