### PR TITLE
Limit source file types to Swift and headers

### DIFF
--- a/SeedStackViewController.podspec
+++ b/SeedStackViewController.podspec
@@ -12,6 +12,6 @@ StackViewController is a Swift framework that simplifies the process of building
   s.author           = { "Indragie Karunaratne" => "i@indragie.com" }
   s.source           = { :git => "https://github.com/seedco/StackViewController.git", :tag => s.version.to_s }
   s.ios.deployment_target = '9.0'
-  s.source_files = 'StackViewController/**/*.{h,swift}'
+  s.source_files = 'StackViewController/*.{h,swift}'
   s.frameworks = 'UIKit'
 end

--- a/SeedStackViewController.podspec
+++ b/SeedStackViewController.podspec
@@ -12,6 +12,6 @@ StackViewController is a Swift framework that simplifies the process of building
   s.author           = { "Indragie Karunaratne" => "i@indragie.com" }
   s.source           = { :git => "https://github.com/seedco/StackViewController.git", :tag => s.version.to_s }
   s.ios.deployment_target = '9.0'
-  s.source_files = 'StackViewController/**'
+  s.source_files = 'StackViewController/**/*.{h,swift}'
   s.frameworks = 'UIKit'
 end


### PR DESCRIPTION
This fixes a bug where the Info.plist file from this repo was included in the compile sources phase, which causes a build failure with the new Xcode 9 build system.