### PR TITLE
Release 0.4.0

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -16,7 +16,7 @@ class ViewController: UIViewController {
     
     init() {
         stackViewController = StackViewController()
-        stackViewController.stackViewContainer.separatorViewFactory = StackViewContainer.createSeparatorViewFactory()
+        stackViewController.separatorViewFactory = StackViewContainer.createSeparatorViewFactory()
         
         super.init(nibName: nil, bundle: nil)
         

--- a/SeedStackViewController.podspec
+++ b/SeedStackViewController.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description = "StackViewController is a Swift framework that simplifies the process of building forms and other static content using UIStackView.
   s.homepage = "https://github.com/seedco/StackViewController"
   s.license = "MIT"
-  s.author = { "Indragie Karunaratne" => "i@indragie.com" }
+  s.author = "Seed"
   s.source = {
     git: "https://github.com/seedco/StackViewController.git",
     tag: s.version.to_s

--- a/SeedStackViewController.podspec
+++ b/SeedStackViewController.podspec
@@ -1,17 +1,17 @@
 Pod::Spec.new do |s|
-  s.name             = "SeedStackViewController"
-  s.module_name      = "StackViewController"
-  s.version          = "0.3.1"
-  s.summary          = "Simplifies the process of building forms and other static content using UIStackView."
-  s.description      = <<-DESC
-StackViewController is a Swift framework that simplifies the process of building forms and other static content using UIStackView.
-                       DESC
-
-  s.homepage         = "https://github.com/seedco/StackViewController"
-  s.license          = 'MIT'
-  s.author           = { "Indragie Karunaratne" => "i@indragie.com" }
-  s.source           = { :git => "https://github.com/seedco/StackViewController.git", :tag => s.version.to_s }
-  s.ios.deployment_target = '9.0'
-  s.source_files = 'StackViewController/*.{h,swift}'
-  s.frameworks = 'UIKit'
+  s.name = "SeedStackViewController"
+  s.module_name = "StackViewController"
+  s.version = "0.4.0"
+  s.summary = "Simplifies the process of building forms and other static content using UIStackView."
+  s.description = "StackViewController is a Swift framework that simplifies the process of building forms and other static content using UIStackView.
+  s.homepage = "https://github.com/seedco/StackViewController"
+  s.license = "MIT"
+  s.author = { "Indragie Karunaratne" => "i@indragie.com" }
+  s.source = {
+    git: "https://github.com/seedco/StackViewController.git",
+    tag: s.version.to_s
+  }
+  s.ios.deployment_target = "9.0"
+  s.source_files = "StackViewController/*.{h,swift}"
+  s.frameworks = "UIKit"
 end

--- a/StackViewController.xcodeproj/project.pbxproj
+++ b/StackViewController.xcodeproj/project.pbxproj
@@ -267,7 +267,7 @@
 					};
 					72D193EC1CC3576A00645F83 = {
 						CreatedOnToolsVersion = 7.3;
-						LastSwiftMigration = 0810;
+						LastSwiftMigration = 0910;
 					};
 					72D1940A1CC357A100645F83 = {
 						CreatedOnToolsVersion = 7.3;
@@ -542,7 +542,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = co.seed.StackViewControllerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -553,7 +553,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = co.seed.StackViewControllerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/StackViewController/StackViewController.swift
+++ b/StackViewController/StackViewController.swift
@@ -14,12 +14,6 @@ import UIKit
 /// controllers via the API exposed in this class. Adding and removing these
 /// child view controllers is managed automatically.
 open class StackViewController: UIViewController {
-    /// This is exposed for configuring `backgroundView`, `stackView`
-    /// `axis`, and `separatorViewFactory`. All other operations should
-    /// be performed via this controller and not directly via the container view.
-    @available(*, deprecated, message: "Use the `backgroundView`, `stackView`, `axis`, `separatorViewFactory` or `scrollView` property on `StackViewController` instead.")
-    open lazy var stackViewContainer = StackViewContainer()
-
     /// An optional background view that is shown behind the stack view. The
     /// top of the background view will be kept pinned to the top of the scroll
     /// view bounds, even when bouncing.
@@ -76,6 +70,8 @@ open class StackViewController: UIViewController {
     open var scrollView: UIScrollView {
         return stackViewContainer.scrollView
     }
+
+    private lazy var stackViewContainer = StackViewContainer()
     
     fileprivate var _items = [StackViewItem]()
     


### PR DESCRIPTION
Cut a 0.4.0 release with the following changes:

- Swift 4.0.2 (Xcode 9.1) support
- Remove deprecated `stackViewContainer` property