### PR TITLE
Mark UIKit extensions as @objc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# [Unreleased](https://github.com/seedco/StackViewController/compare/0.4.0...HEAD)
+
+- Fix runtime crashes (unrecognized selector) by adding `@objc` annotation to public UIKit extensions. 

--- a/StackViewController/UIStackViewExtensions.swift
+++ b/StackViewController/UIStackViewExtensions.swift
@@ -8,8 +8,8 @@
 
 import UIKit
 
-extension UIStackView {
-    public func removeAllArrangedSubviews() {
+public extension UIStackView {
+    @objc public func removeAllArrangedSubviews() {
         arrangedSubviews.forEach {
             $0.removeFromSuperview()
         }

--- a/StackViewController/UIViewExtensions.swift
+++ b/StackViewController/UIViewExtensions.swift
@@ -8,8 +8,8 @@
 
 import UIKit
 
-extension UIView {
-    public func activateSuperviewHuggingConstraints(insets: UIEdgeInsets = UIEdgeInsets.zero) -> [NSLayoutConstraint] {
+public extension UIView {
+    @objc public func activateSuperviewHuggingConstraints(insets: UIEdgeInsets = UIEdgeInsets.zero) -> [NSLayoutConstraint] {
         translatesAutoresizingMaskIntoConstraints = false
         let views = ["view": self]
         let metrics = ["top": insets.top, "left": insets.left, "bottom": insets.bottom, "right": insets.right]


### PR DESCRIPTION
Fixes crashers in the Seed app because the extensions can't be found. Haven't been able to reproduce outside of the Seed app.

This PR also introduces a changelog so we can keep track of what changed between versions.