### PR TITLE
Fixes index error when replacing items array via assignment

### DIFF
--- a/StackViewController/StackViewController.swift
+++ b/StackViewController/StackViewController.swift
@@ -79,7 +79,7 @@ open class StackViewController: UIViewController {
     open var items: [StackViewItem] {
         get { return _items }
         set(newItems) {
-            for (index, _) in _items.enumerated() {
+            for (index, _) in _items.enumerated().reversed() {
                 removeItemAtIndex(index)
             }
             for item in newItems {


### PR DESCRIPTION
This bit of code had an error:

```swift
/// The items displayed by this controller
open var items: [StackViewItem] {
    get { return _items }
    set(newItems) {
        for (index, _) in _items.enumerated() { // <-- HERE
            removeItemAtIndex(index)
        }
        for item in newItems {
            addItem(item, canShowSeparator: true)
        }
    }
}
```

As it looks through the array with the index increasing it will hit an Index Not Found exception once the number of remaining items is less than the current index.

Simple fix was to reverse the enumeration.

```swift
/// The items displayed by this controller
open var items: [StackViewItem] {
    get { return _items }
    set(newItems) {
        for (index, _) in _items.enumerated().reversed() { // <-- SIMPLE FIX
            removeItemAtIndex(index)
        }
        for item in newItems {
            addItem(item, canShowSeparator: true)
        }
    }
}
```

