### PR TITLE
Swift Package Manager Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "StackViewController",
+    platforms: [.iOS(.v9)],
+    products: [
+        .library(
+            name: "StackViewController",
+            targets: ["StackViewController"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "StackViewController",
+            path: "StackViewController"
+        ),
+        .testTarget(
+            name: "StackViewControllerTests",
+            dependencies: ["StackViewController"],
+            path: "StackViewControllerTests"
+        )
+    ]
+)


### PR DESCRIPTION
Adds `Package.swift` file which enables usage with SPM.
**Note**, that the most correct usage with SPM will be possible only when there is new release that includes `Package.swift`. Until then, dependency can be added by branch or commit hash which is not allowed in published packages.